### PR TITLE
Pass at rack_user resource/provider

### DIFF
--- a/libraries/provider_rack_user.rb
+++ b/libraries/provider_rack_user.rb
@@ -39,11 +39,12 @@ class Chef
                 key_array.push(line)
               end
             end
-            ua = Chef::Resource::UserAccount.new('rack', run_context)
-            ua.comment 'Rackspace User'
-            ua.home '/home/rack'
-            ua.ssh_keys key_array
-            ua.run_action :create
+            user_account 'rack' do
+              comment 'Rackspace User'
+              home '/home/rack'
+              ssh_keys key_array
+              action :create
+            end
           end
           action :nothing
         end

--- a/test/unit/spec/rack_user_shared.rb
+++ b/test/unit/spec/rack_user_shared.rb
@@ -10,6 +10,9 @@ shared_examples_for 'create the rack user' do
   end
 
   it 'creates a user rack with the correct keys' do
+    # ssh keys aren't set at this point
+    expect(chef_run).to create_rack_user('default').with(ssh_keys: nil)
+
     expect(chef_run.ruby_block('put_auth_keys_into_array')).to do_nothing
     expect(chef_run).to install_sudo('rack').with(user: 'rack', nopasswd: true)
     expect(chef_run).to include_recipe('user')


### PR DESCRIPTION
- Switched to consistent recipe DSL for user_account
- Added test for rack_user to get us to 100% coverage

Note: I think for this rack_user cookbook, [the gist](https://gist.githubusercontent.com/jujugrrr/af613872c3d029a94c88/raw/1d57582215ac6316f55b956691db1dba8339fcdd/test) isn't a good test, since it's only a single line, and part of the logic is parsing multiline files.
