### PR TITLE
Unlock rack user

### DIFF
--- a/libraries/provider_rack_user.rb
+++ b/libraries/provider_rack_user.rb
@@ -30,6 +30,7 @@ class Chef
           comment 'Rackspace User'
           home '/home/rack'
           ssh_keys key_array
+          password '*'
           action :create
         end
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -28,3 +28,10 @@ describe command('sudo -u rack sudo -l') do
     its(:stdout) { is_expected.to contain('\(ALL\) NOPASSWD: ALL') }
   end
 end
+
+describe file('/etc/shadow') do
+  context 'when the rack user is unlocked' do
+    it { is_expected.to be_file }
+    it { is_expected.to contain('rack:*:') }
+  end
+end


### PR DESCRIPTION
I was not aware of this issue before I made the SSH config a bit more secure.
Let me know if you think this change is not safe.

It allows to ssh as `rack` even when `UsePAM no` is set
http://arlimus.github.io/articles/usepam/
